### PR TITLE
chore: add .env support and update README

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# --------------------------------------------
+# APPLICATION
+# --------------------------------------------
+PORT=8080
+SPRING_PROFILES_ACTIVE=dev
+
+# --------------------------------------------
+# DATABASE (PostgreSQL)
+# --------------------------------------------
+POSTGRES_DB=meliscraper
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=postgres
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.env
+
 HELP.md
 target/
 .mvn/wrapper/maven-wrapper.jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,10 +12,20 @@ RUN mvn clean package -DskipTests
 
 FROM eclipse-temurin:21-jre-alpine-3.21
 
+RUN apk update && apk upgrade --no-cache && rm -rf /var/cache/apk/*
+
 WORKDIR /app
+
+RUN addgroup -S meliscraper && adduser -S meliscraper -G meliscraper
 
 COPY --from=build /app/target/*.jar app.jar
 
+RUN chown -R meliscraper:meliscraper /app
+
+USER meliscraper
+
+HEALTHCHECK --interval=30s --timeout=3s --start-period=60s --retries=3 \
+    CMD wget --quiet --tries=1 --spider http://localhost:8080/actuator/health || exit 1
 EXPOSE 8080
 
 ENTRYPOINT ["java","-jar","app.jar"]

--- a/README.md
+++ b/README.md
@@ -55,18 +55,28 @@ docker compose up -d --build
 
 Then access the application at `http://localhost:8080/` (or the port you configured).
 
-> [!NOTE]
-> **Optionally**, you can override any environment variables with your own settings.
+**Optionally**, you can override any environment variables with your own settings.
+```bash
+cp .env.example .env
+# Edit .env with your local values
+```
 
 ### Running Locally (Without Docker)
 
 1. Create a PostgreSQL database 
-2. Set required environment variables:
-```bash
-export POSTGRES_USER=<your-user-here>  
-export POSTGRES_PASSWORD=<your-password-here>  
-export POSTGRES_DB=<database-name>
-```
+2. Set the required environment variables using **either** method below:
+  - **Option 1: Using `.env` file**. Copy the example file and edit with your values:
+    ```bash
+    cp .env.example .env
+    # Edit .env with your local settings
+    ```
+
+  - **Option 2: Exporting via shell**
+    ```bash
+    export POSTGRES_USERNAME=<your-postgresql-user-here>
+    export POSTGRES_PASSWORD=<your-postgresql-password-here>
+    export POSTGRES_DB=<database-name>
+    ```
 3. (Optional) Set server port
 ```bash
 export PORT=8081

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
     ports:
       - "${PORT:-8080}:${PORT:-8080}"
     environment:
+      SPRING_PROFILES_ACTIVE: dev
       PORT: "${PORT:-8080}"
       POSTGRES_USER: "${POSTGRES_USER:-admin}"
       POSTGRES_PASSWORD: "${POSTGRES_PASSWORD:-password}"

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,6 +3,7 @@ server.port=${PORT:8080}
 
 # ====== GENERAL ======
 spring.application.name=meliscraper
+spring.config.import=optional:file:.env[.properties]
 
 # ====== DATABASE ======
 spring.datasource.url=jdbc:postgresql://${POSTGRES_HOST:localhost}:5432/${POSTGRES_DB:meliscraper}


### PR DESCRIPTION
## What changed
- Configured `.env` usage in local development without Docker
- Updated README with `.env` file usage instructions. 
- Improved `Dockerfile` security by adding healthcheck and configuring non-root user.
- Configured `dev` profile as default active profile in Docker Compose environment. 